### PR TITLE
bump deps to fix breaking change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-alloy-json-rpc = "0.13.0"
-alloy-primitives = { version = "0.8.15", default-features = false }
-alloy-rpc-types-eth = "0.13.0"
+alloy-json-rpc = "1.0.35"
+alloy-primitives = { version = "1.3.1", default-features = false }
+alloy-rpc-types-eth =  "1.0.35"
 bytes = "1.10.0"
 crossbeam = "0.8.4"
 dashmap = "6.1.0"


### PR DESCRIPTION
There's an issue with a few of the dependencies being outdated. It is breaking because one of the Alloy crates tries to import a module from Serde that has since been made private. 
Bumping all the Alloy deps appears to fix it. 